### PR TITLE
Automatic update of docker image mcr.microsoft.com/dotnet/core/sdk to 3.1.405

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.405


### PR DESCRIPTION
UpDock has generated an update of `mcr.microsoft.com/dotnet/core/sdk` from `2.2` to `3.1.405`

1 file(s) updated
Updated `Dockerfile` to `mcr.microsoft.com/dotnet/core/sdk` `2.2` to `3.1.405`

This is an automated update. Merge only if it passes tests.
